### PR TITLE
Return more information from pretreatment()

### DIFF
--- a/R/pretreatment.R
+++ b/R/pretreatment.R
@@ -41,8 +41,10 @@
 #'
 pretreatment <- function(params, serie, Int=TRUE, first=NULL, last=NULL, yrInterp=NULL) {
 
-  ## This is the R version of the CharAnalysis CharPretreatment.m function
-  ## originally develloped by P. Higuera and available at https://sites.google.com/site/charanalysis
+  ## This is the R version of the CharAnalysis Matlab CharPretreatment.m function
+  ## originally implemented by P. Higuera and available at https://sites.google.com/site/charanalysis,
+  ## The Matlab code was translated to R language here by Olivier Blarquez,
+  ## then modified by Walter Finsinger to get the full output.
   ## Requires a matrix as input with the following columns
   ## CmTop CmBot AgeTop AgeBot Volume
   ## And a serie from which to calculate accumulation rates
@@ -203,7 +205,10 @@ pretreatment <- function(params, serie, Int=TRUE, first=NULL, last=NULL, yrInter
   # multiply by Charcoal.conI to get Charcoal.accI
 
   ## Return values
-  output <- structure(list(cmI = cmI, ybpI = ybpI, accI = accI, ageTop = ageTop, ageBot = ageBot, yrInterp = yrInterp, acc = acc))
+  output <- structure(list(
+    cmI = cmI, ybpI = ybpI, countI = countI, volI = volI, conI = conI,
+    accI = accI, ageTop = ageTop, ageBot = ageBot, yrInterp = yrInterp, acc = acc
+  ))
   class(output) <- "CHAR"
   return(output)
   ## Et Hop


### PR DESCRIPTION
Hello @oblarquez,

@wfinsinger uses the `pretreatment()` function of PaleoFire in their package [PaleoAnomalies](https://github.com/wfinsinger/R-PaleoAnomalies),
but they need that more information be returned, which requires this minor modification of the return statement.

The current situation is that a slightly modified copy of `pretreatment()` lives in PaleoAnomalies repo ([there](https://github.com/wfinsinger/R-PaleoAnomalies/blob/main/R/pretreatment_full.R)). This is unsatisfactory because PaleoFire is not acknowledged as a formal dependency of PaleoAnomalies, and because future updates to PaleoFire will not automatically propagate to PaleoAnomalies.

As the current [`com`piler](https://journal.r-project.org/archive/2012-1/RJournal_2012-1_Hornik~et~al.pdf) of PaleoAnomalies, I suggest that this modification be made here instead, in PaleoFire official repo. All you have to do is to accept this PR, then run your tests to check that nothing is broken by this slight extension of the list returned (I would be suprised if anything did). Then I'll be able to declare `paleofire::pretreatment()` a formal dependency of PaleoAnomalies.